### PR TITLE
Interrupt Timer Implementation

### DIFF
--- a/tb_timer.vhd
+++ b/tb_timer.vhd
@@ -1,0 +1,71 @@
+-- Copyright (C) 2018  Intel Corporation. All rights reserved.
+-- Your use of Intel Corporation's design tools, logic functions 
+-- and other software and tools, and its AMPP partner logic 
+-- functions, and any output files from any of the foregoing 
+-- (including device programming or simulation files), and any 
+-- associated documentation or information are expressly subject 
+-- to the terms and conditions of the Intel Program License 
+-- Subscription Agreement, the Intel Quartus Prime License Agreement,
+-- the Intel FPGA IP License Agreement, or other applicable license
+-- agreement, including, without limitation, that your use is for
+-- the sole purpose of programming logic devices manufactured by
+-- Intel and sold by Intel or its authorized distributors.  Please
+-- refer to the applicable agreement for further details.
+
+-- ***************************************************************************
+-- This file contains a Vhdl test bench template that is freely editable to   
+-- suit user's needs .Comments are provided in each section to help the user  
+-- fill out necessary details.                                                
+-- ***************************************************************************
+-- Generated on "09/25/2018 20:52:30"
+                                                            
+-- Vhdl Test Bench template for design  :  timer
+-- 
+-- Simulation tool : ModelSim-Altera (VHDL)
+-- 
+
+LIBRARY ieee;                                               
+USE ieee.std_logic_1164.all;                                
+
+ENTITY tb_timer IS
+END tb_timer;
+ARCHITECTURE timer_arch OF tb_timer IS
+-- constants                                                 
+-- signals                                                   
+SIGNAL clk : STD_LOGIC := '0';
+SIGNAL interrupt_n : STD_LOGIC;
+SIGNAL rst_n : STD_LOGIC := '1';
+COMPONENT timer
+	PORT (
+	clk : IN STD_LOGIC;
+	interrupt_n : BUFFER STD_LOGIC;
+	rst_n : IN STD_LOGIC
+	);
+END COMPONENT;
+BEGIN
+	i1 : timer
+	PORT MAP (
+-- list connections between master ports and signals
+	clk => clk,
+	interrupt_n => interrupt_n,
+	rst_n => rst_n
+	);
+
+	clk_process : process
+   begin
+        clk <= '0';
+        wait for 10 ns;
+        clk <= '1';
+        wait for 10 ns;
+   end process;
+	
+	simProcess : process
+	begin
+		wait for 150 ms;
+		rst_n <= '0';
+		wait for 10 ms;
+		rst_n <= '1';
+	end process;
+	
+                                         
+END timer_arch;

--- a/timer.vhd
+++ b/timer.vhd
@@ -1,1 +1,44 @@
 -- Timer
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity timer is
+generic (
+	timeNS: Integer := 1000000000;
+	masterClkPeriodNS: Integer := 20						--50 MHz clock = 20 ns period
+);
+
+port (
+	RST, CLK: 	in std_logic;
+	interrupt: 	out std_logic
+);
+end entity timer;
+
+architecture BEHAVIORAL of timer is
+
+begin
+
+	timer: process(CLK, RST) is
+	variable cnt: Integer := 0;
+	variable limit: Integer := timeNS / masterClkPeriodNS;
+	
+	begin
+		--increment count value on rising edge or reset count on reset signal
+		if RST = '0' then
+			cnt := 0;
+		elsif rising_edge(CLK) then
+			cnt := cnt + 1;
+		end if;
+		
+		--set interrupt to 0 if the count limit has been reached; otherwise 1
+		if cnt = limit-1 then
+			interrupt <= '0';
+		else
+			interrupt <= '1';
+		end if;
+	end process;
+		
+
+end architecture BEHAVIORAL;
+	

--- a/timer.vhd
+++ b/timer.vhd
@@ -5,40 +5,42 @@ use ieee.std_logic_1164.all;
 
 entity timer is
 generic (
-	timeNS: Integer := 1000000000;
+	timeNS: Integer := 100000000;
 	masterClkPeriodNS: Integer := 20						--50 MHz clock = 20 ns period
 );
 
 port (
-	RST, CLK: 	in std_logic;
-	interrupt: 	out std_logic
+	rst_n, clk: 	in std_logic;
+	interrupt_n: 	out std_logic
 );
 end entity timer;
 
-architecture BEHAVIORAL of timer is
+architecture behavioral of timer is
 
 begin
 
-	timer: process(CLK, RST) is
+	timer: process(clk, rst_n) is
 	variable cnt: Integer := 0;
 	variable limit: Integer := timeNS / masterClkPeriodNS;
 	
 	begin
 		--increment count value on rising edge or reset count on reset signal
-		if RST = '0' then
+		if rst_n = '0' then
 			cnt := 0;
-		elsif rising_edge(CLK) then
-			cnt := cnt + 1;
+		elsif rising_edge(clk) then
+			if cnt < limit-1 then
+				cnt := cnt + 1;
+			end if;
 		end if;
 		
 		--set interrupt to 0 if the count limit has been reached; otherwise 1
 		if cnt = limit-1 then
-			interrupt <= '0';
+			interrupt_n <= '0';
 		else
-			interrupt <= '1';
+			interrupt_n <= '1';
 		end if;
 	end process;
 		
 
-end architecture BEHAVIORAL;
+end architecture behavioral;
 	


### PR DESCRIPTION
I have implemented the timer using active low signals using generics that allow the timer to be configured depending on system clock and timeout specification. When a timeout occurs  (100 ms in this case), the interrupt_n signal goes low and remains low until a reset is triggered by setting the reset_n signal low and then high. Timer does not begin counting until the reset_n signal is brought back high.

Correct functionality is demonstrated in this test bench output:
![image](https://user-images.githubusercontent.com/17710406/46056588-f776cf00-c116-11e8-86b6-7bded28396f9.png)
