### PR TITLE
Initial implementaion of channel monitor for STM32 board

### DIFF
--- a/inc/ADC.h
+++ b/inc/ADC.h
@@ -1,0 +1,56 @@
+/*
+ * ADC.h
+ *
+ *  Created on: Jan 11, 2017
+ *      Author: Mitchell Larson
+ */
+
+#ifndef ADC_H
+#define ADC_H
+
+//ADC constants
+#define ADC_BASE 	(volatile uint32_t*)	0x40012000
+#define ADC_SR 	 	(volatile uint32_t*)	0x40012000
+#define ADC_CR1	 	(volatile uint32_t*)	0x40012004
+#define ADC_CR2  	(volatile uint32_t*)	0x40012008
+#define ADC_SMPR1	(volatile uint32_t*)	0x4001200C
+#define ADC_SMPR2	(volatile uint32_t*)	0x40012010
+#define ADC_HTR		(volatile uint32_t*)	0x40012024
+#define ADC_LTR		(volatile uint32_t*)	0x40012028
+#define ADC_SQR1	(volatile uint32_t*)	0x4001202C
+#define ADC_SQR2	(volatile uint32_t*)	0x40012030
+#define ADC_SQR3	(volatile uint32_t*)	0x40012034
+#define ADC_DR		(volatile uint32_t*)	0x4001204C
+
+//RCC constants
+#define RCC_BASE	(volatile uint32_t*)	0x40023800
+#define APB2ENR		(volatile uint32_t*)	0x40023844
+#define APB1ENR		(volatile uint32_t*)	0x40023840
+
+//NVIC constants
+#define NVIC_ISER0 (volatile uint32_t*)		0xE000E100
+
+//TIM2 constants
+#define TIM2_PSC 	(volatile uint32_t*)	0x40000028
+#define TIM2_ARR	(volatile uint32_t*)	0x4000002C
+#define TIM2_CCR1	(volatile uint32_t*)	0x40000034
+#define TIM2_CCR2	(volatile uint32_t*)	0x40000038
+#define TIM2_CCMR1	(volatile uint32_t*)	0x40000018
+#define TIM2_CCER	(volatile uint32_t*)	0x40000020
+#define TIM2_CR1	(volatile uint32_t*)	0x40000000
+#define TIM2_EGR	(volatile uint32_t*)	0x40000014
+#define TIM2_DIER	(volatile uint32_t*)	0x4000000C
+#define TIM2_SR		(volatile uint32_t*)	0x40000010
+#define TIM2_CNT	(volatile uint32_t*)	0x40000024
+
+
+#include <inttypes.h>
+#include "gpio.h"
+
+extern void ADC_init();
+extern uint32_t take_sample();
+extern float get_tempC();
+extern float get_tempF();
+extern float get_mili_volts();
+
+#endif /* ADC_H */

--- a/inc/Manchester_State.h
+++ b/inc/Manchester_State.h
@@ -1,0 +1,21 @@
+/*
+ * Manchester_State.h
+ *
+ *  Created on: Oct 6, 2018
+ *      Author: larsonma
+ */
+
+#ifndef MANCHESTER_STATE_H_
+#define MANCHESTER_STATE_H_
+
+#include "interrupt_timer.h"
+#include "RX.h"
+
+#define ISPR0 (volatile uint32_t*) 0xE000E200
+
+enum STATES {IDLE, BUSY, COLLISION};
+
+extern void init_state();
+enum STATES getState();
+
+#endif /* MANCHESTER_STATE_H_ */

--- a/inc/RCC.h
+++ b/inc/RCC.h
@@ -1,0 +1,59 @@
+/*
+ * RCC.h
+ *
+ *  Created on: Jan. 6 2017
+ *      Author: Mitchell Larson
+ */
+
+#ifndef RCC_H
+#define RCC_H
+
+#include <stdint.h>
+
+#define DBP 8
+#define RCC_RTCCLKSource 8
+#define LSE_ON 1
+#define RTC_ENABLE 15
+
+typedef struct{
+	uint32_t CR;
+	uint32_t PLLCFGR;
+	uint32_t CFGR;
+	uint32_t CIR;
+	uint32_t AHB1RSTR;
+	uint32_t AHB2RSTR;
+	uint32_t AHB3RSTR;
+	const uint32_t blank1;
+	uint32_t APB1RSTR;
+	uint32_t APB2RSTR;
+	const uint32_t blank2;
+	const uint32_t blank3;
+	uint32_t AHB1ENR;
+	uint32_t AHB2ENR;
+	uint32_t AHB3ENR;
+	const uint32_t blank4;
+	uint32_t APB1ENR;
+	uint32_t APB2ENR;
+	const uint32_t blank5;
+	const uint32_t blank6;
+	uint32_t AHB1LPENR;
+	uint32_t AHB2LPENR;
+	uint32_t AHB3LPENR;
+	const uint32_t blank7;
+	uint32_t APB1LPENR;
+	uint32_t APB2LPENR;
+	const uint32_t blank8;
+	const uint32_t blank9;
+	uint32_t BDCR;
+	uint32_t CSR;
+	const uint32_t blank10;
+	const uint32_t blank11;
+	uint32_t SSCGR;
+	uint32_t PLLI2SCFGR;
+	uint32_t PLLSAICFGR;
+	uint32_t DCKCFGR;
+	uint32_t CKGATENR;
+	uint32_t DCKCFGR2;
+} RCC_Struct;
+
+#endif

--- a/inc/RTC.h
+++ b/inc/RTC.h
@@ -1,0 +1,69 @@
+/*
+ * RTC.h
+ *
+ *  Created on: Jan. 6 2017
+ *      Author: Mitchell Larson
+ */
+
+#ifndef RTC_H
+#define RTC_H
+
+#include <stdint.h>
+#include "date.h"
+#include <string.h>
+#include <stdio.h>
+
+#define INIT 7
+#define INITF 6
+#define SYNCHPREDIV 255
+#define ASYNCHPREDIV 127
+#define PM 22
+#define FMT 6
+#define TIME_LENGTH 11
+
+typedef struct{
+	uint32_t TR;
+	uint32_t DR;
+	uint32_t CR;
+	uint32_t ISR;
+	uint32_t PRER;
+	uint32_t WUTR;
+	uint32_t CALIBR;
+	uint32_t ALRMAR;
+	uint32_t ALRMBR;
+	uint32_t WPR;
+	uint32_t SSR;
+	uint32_t SHIFTR;
+	uint32_t TSTR;
+	uint32_t TSDR;
+	uint32_t TSSSR;
+	uint32_t CALR;
+	uint32_t TAFCR;
+	uint32_t ALRMASSR;
+	uint32_t ALRMBSSR;
+	//backup registers
+}RTC_Struct;
+
+typedef enum {HOUR24, HOUR12} H12;
+
+typedef struct{
+	uint8_t RTC_Hours;
+	uint8_t RTC_Minutes;
+	uint8_t RTC_Seconds;
+	H12 timeMode;
+} RTC_Time;
+
+typedef struct{
+	WeekDay RTC_WeekDay;
+	Month RTC_Month;
+	uint8_t RTC_Date; 		//1-31
+	uint8_t RTC_Year;		//0-99
+} RTC_Date;
+
+extern void init_rtc(RTC_Date*,RTC_Time*);
+extern void setDate(RTC_Date*);
+extern void setTime(RTC_Time*);
+extern char* time_to_string(char* time);
+extern uint8_t get_Hour();
+
+#endif

--- a/inc/RX.h
+++ b/inc/RX.h
@@ -1,0 +1,32 @@
+/*
+ * RX.h
+ *
+ *  Created on: Oct 6, 2018
+ *      Author: larsonma
+ */
+
+#ifndef RX_H_
+#define RX_H_
+
+#include <inttypes.h>
+
+#include "gpio.h"
+
+#define NVIC_ISER0 (volatile uint32_t*)		0xE000E100
+#define APB2ENR		(volatile uint32_t*)	0x40023844
+#define EXTICR1		(volatile uint32_t*)	0x40013808
+#define NVIC_IPR1		(volatile uint32_t*)	0xE000E404
+
+typedef struct{
+	uint32_t IMR;
+	uint32_t EMR;
+	uint32_t RTSR;
+	uint32_t FTSR;
+	uint32_t SWIER;
+	uint32_t PR;
+} EXTI;
+
+
+extern void init_RX_channel();
+
+#endif /* RX_H_ */

--- a/inc/date.h
+++ b/inc/date.h
@@ -1,0 +1,15 @@
+/*
+ * date.h
+ *
+ *  Created on: Jan. 6 2017
+ *      Author: Mitchell Larson
+ */
+
+#ifndef DATE_H
+#define DATE_H
+
+//enumerated type for date
+typedef enum {MONDAY=1,TUESDAY=2,WEDNESDAY=3,THURSDAY=4,FRIDAY=5,SATURDAY=6,SUNDAY=7} WeekDay;
+typedef enum {JAN=1,FEB=2,MAR=3,APR=4,MAY=5,JUN=6,JUL=7,AUG=8,SEP=9,OCT=10,NOV=11,DEC=12} Month;
+
+#endif

--- a/inc/gpio.h
+++ b/inc/gpio.h
@@ -1,0 +1,47 @@
+/*
+ * gpio.h
+ *
+ *  Created on: Dec 16, 2016
+ *      Author: Mitchell Larson
+ */
+
+#ifndef GPIO_H
+#define GPIO_H
+ 
+#include <inttypes.h>
+#include <stddef.h>
+
+//RCC constants 
+#define RCC_AHB1ENR (volatile uint32_t*) 	0x40023830
+#define GPIOA_RCCEN_F 0
+#define GPIOB_RCCEN_F 1
+#define GPIOC_RCCEN_F 2
+
+typedef struct{
+	uint32_t MODER;
+	uint32_t OTYPER;
+	uint32_t OSPEEDR;
+	uint32_t PUPDR;
+	uint32_t IDR;
+	uint32_t ODR;
+	uint32_t BSSR;
+	uint32_t LCKR;
+	uint32_t AFRL;
+	uint32_t AFRH;
+} GPIOx;
+
+//enumerated types
+typedef enum {INPUT, OUTPUT, ALTFUNC, ANALOG} Mode;
+typedef enum {PUSH_PULL, OPEN_DRAIN} OutputType;
+typedef enum {LOW, MED, FAST, HIGH} Speed;
+typedef enum {NONE, PULLUP, PULLDOWN} PullType;
+
+//global functions
+extern void enable_clock(char port);
+extern void set_pin_mode(char port, uint8_t pin, Mode mode);
+extern void set_pin_output_type(char port, uint8_t pin, OutputType outtype);
+extern void set_output_speed(char port, uint8_t pin, Speed speed);
+extern void set_pin_PUPDR(char port, uint8_t pin, PullType pulltype);
+extern void set_alt_func(char port, uint8_t pin, uint8_t altFunc);
+
+#endif /* GPIO_H */

--- a/inc/interrupt_timer.h
+++ b/inc/interrupt_timer.h
@@ -1,0 +1,36 @@
+/*
+ * interrupt_timer.h
+ *
+ *  Created on: Oct 6, 2018
+ *      Author: larsonma
+ */
+
+#ifndef INTERRUPT_TIMER_H_
+#define INTERRUPT_TIMER_H_
+
+#include <inttypes.h>
+
+//NVIC constants
+#define NVIC_ISER0 (volatile uint32_t*)		0xE000E100
+
+//TIM2 constants
+#define TIM2_PSC 	(volatile uint32_t*)	0x40000028
+#define TIM2_ARR	(volatile uint32_t*)	0x4000002C
+#define TIM2_CCR1	(volatile uint32_t*)	0x40000034
+#define TIM2_CCR2	(volatile uint32_t*)	0x40000038
+#define TIM2_CCMR1	(volatile uint32_t*)	0x40000018
+#define TIM2_CCER	(volatile uint32_t*)	0x40000020
+#define TIM2_CR1	(volatile uint32_t*)	0x40000000
+#define TIM2_EGR	(volatile uint32_t*)	0x40000014
+#define TIM2_DIER	(volatile uint32_t*)	0x4000000C
+#define TIM2_SR		(volatile uint32_t*)	0x40000010
+#define TIM2_CNT	(volatile uint32_t*)	0x40000024
+
+//RCC constants
+#define RCC_BASE	(volatile uint32_t*)	0x40023800
+#define APB2ENR		(volatile uint32_t*)	0x40023844
+#define APB1ENR		(volatile uint32_t*)	0x40023840
+
+extern void init_interrupt_timer();
+
+#endif /* INTERRUPT_TIMER_H_ */

--- a/inc/keypad.h
+++ b/inc/keypad.h
@@ -1,0 +1,34 @@
+/*
+ * keypad.h
+ *
+ *  Created on: Jan. 6 2017
+ *      Author: Mitchell Larson
+ */
+
+#ifndef KEYPAD_H
+#define KEYPAD_H
+
+#include <inttypes.h>
+#include "gpio.h"
+#include "ringbuffer.h"
+
+#define RCC_APB2ENR (volatile uint32_t*) 0x40023844
+#define SYSCFG_EXTICR1 (volatile uint32_t*) 0x40013808
+#define SYSCFG_EXTICR2 (volatile uint32_t*) 0x4001380C
+#define SYSCFG_EXTICR3 (volatile uint32_t*) 0x40013810
+
+#define EXTI_FTSR (volatile uint32_t*) 0x40013C0C
+#define NVIC_ISER0 (volatile uint32_t*) 0xE000E100
+#define NVIC_ICER0 (volatile uint32_t*) 0xE000E180
+#define EXTI_PR (volatile uint32_t*) 0x40013C14
+#define EXTI_IMR (volatile uint32_t*) 0x40013C00
+
+//global functions
+extern void key_init();
+extern uint8_t key_getkey_noblock();
+extern uint8_t key_getkey();
+extern char key_getchar();
+extern uint8_t key_getint();
+extern char key_getchar_noblock();
+
+#endif /* KEYPAD_H */

--- a/inc/lcd.h
+++ b/inc/lcd.h
@@ -1,0 +1,50 @@
+/*
+ * lcd.h
+ *
+ *  Created on: Jan. 5 2017
+ *      Author: Mitchell Larson
+ */
+
+#ifndef LCD_H
+#define LCD_H
+
+//included libraries
+#include <inttypes.h>
+#include "gpio.h"
+#include <stdio.h>
+#include "timer.h"
+
+static volatile GPIOx *GPIOB = (GPIOx *) 0x40020400;
+static volatile GPIOx *GPIOC = (GPIOx *) 0x40020800;
+
+ 
+//RCC constants
+#define RCC_AHB1ENR (volatile uint32_t*) 0x40023830
+#define GPIOB_EN_F 1
+ 
+//GPIO constants
+#define GPIOB_BASE (volatile uint32_t*) 0x40020400
+
+//LCD constants
+#define LCD_DATA_OFFSET  8
+#define LCD_E_F  2
+#define LCD_RW_F 1
+#define LCD_RS_F 0
+
+#define MAX_INT 9
+
+typedef enum {C_OFF, C_ON} Cursor_Mode;
+
+extern void lcd_init(Cursor_Mode mode);
+extern void lcd_clear();
+extern void lcd_home();
+extern void lcd_reset();
+extern void lcd_row0();
+extern void lcd_row1();
+extern void lcd_cmd(uint8_t command);
+extern void lcd_data(uint8_t data);
+extern void lcd_set_position(uint8_t row,uint8_t col);
+extern int lcd_print_string(const char *pointer);
+extern int lcd_print_num(int num);
+
+#endif /* LCD_H */

--- a/inc/piezo.h
+++ b/inc/piezo.h
@@ -1,0 +1,59 @@
+/*
+ * piezo.h
+ *
+ *  Created on: Jan 25, 2017
+ *      Author: Mitchell Larson
+ */
+
+#ifndef PIEZO_H
+#define PIEZO_H
+
+//libraries needed
+#include <inttypes.h>
+#include "gpio.h" 
+#include "timer.h"
+
+//Data Structures
+typedef enum {
+	C, D, E, F, G, A, B, REST
+} Letter;
+
+typedef enum {
+	FLAT=-1, NATURAL=0, SHARP=1
+} Accidental;
+ 
+typedef struct {
+	Letter letter;
+	Accidental accidental;
+	uint8_t octave;
+	float duration_ms;
+} Note;
+
+typedef struct {
+	double frequency;
+	float duration_ms;
+} Tone;
+
+
+//macros used
+#define STK_ENABLE 0x01
+#define STK_TICKINT 0x02
+#define STK_CLKSOURCE 0x04
+#define STK_COUNTFLAG 0x10000
+
+#define APB1ENR_TIM3_ENABLE 1<<1
+
+#define GPIOB_ODR (volatile uint32_t*) 		0x40020414
+#define APB1ENR (volatile uint32_t*) 		0x40023840
+#define TIM3_OUTPUT_MODE_TOGGLE 0x07<<4
+#define TIM3_OUTPUT_EN 0x01
+#define TIM3_ON 0x01
+
+//fucntions
+extern void init_piezo();
+extern void play_note(const Note *note);
+extern void play_tone(const Tone *tone);
+extern void play_note_sequence(const Note *notes, uint32_t length);
+extern void play_tone_sequence(const Tone *tones, uint32_t length);
+
+#endif /* PIEZO_H */

--- a/inc/ringbuffer.h
+++ b/inc/ringbuffer.h
@@ -1,0 +1,27 @@
+/*
+ * ringbuffer.h
+ *
+ *  Created on: Jan 30, 2017
+ *      Author: Mitchell Larson
+ */
+
+#ifndef RINGBUFFER_H
+#define RINGBUFFER_H
+
+#include <stdint.h>
+
+#define BUF_SIZE 50
+#define BACK_SPACE 127
+
+typedef struct {
+	unsigned int put;
+	unsigned int get;
+	uint8_t buffer[BUF_SIZE];
+} RingBuffer;
+
+extern void put(volatile RingBuffer* buffer, uint8_t element);
+extern uint8_t get(volatile RingBuffer* buffer);
+extern int hasSpace(volatile RingBuffer* buffer);
+extern int hasElement(volatile RingBuffer* buffer);
+
+#endif	/*RINGBUFFER_H*/

--- a/inc/timer.h
+++ b/inc/timer.h
@@ -1,0 +1,25 @@
+/*
+ * timer.h
+ *
+ *  Created on: Jan. 5 2017
+ *      Author: Mitchell Larson
+ */
+
+#ifndef TIMER_H
+#define TIMER_H
+
+
+//SysTic constants
+#define STK_CTRL (volatile uint32_t*) 0xE000E010
+#define STK_LOAD (volatile uint32_t*) 0xE000E014
+#define STK_VAL (volatile uint32_t*) 0xE000E018
+#define STK_ENABLE_F 0
+#define STK_CLKSOURCE_F 2
+#define STK_CNTFLAG_F 16
+
+#include <inttypes.h>
+
+extern void delay_ms(uint32_t t_ms);
+extern void delay_us(uint32_t t_us);
+
+#endif /* TIMER_H */

--- a/inc/uart_driver.h
+++ b/inc/uart_driver.h
@@ -1,0 +1,44 @@
+/*
+ * uart_driver.h
+ *
+ *  Created on: Nov 8, 2016
+ *      Author: barnekow
+ */
+
+#ifndef UART_DRIVER_H_
+#define UART_DRIVER_H_
+
+#include <inttypes.h>
+
+// RCC registers
+#define RCC_APB1ENR (volatile uint32_t*) 0x40023840
+#define RCC_AHB1ENR (volatile uint32_t*) 0x40023830
+
+#define GPIOAEN 0		// GPIOA Enable is bit 0 in RCC_APB1LPENR
+#define USART2EN 17  // USART2 enable is bit 17 in RCC_AHB1LPENR
+
+// GPIOA registers
+#define GPIOA_MODER (volatile uint32_t*) 0x40020000
+#define GPIOA_AFRL  (volatile uint32_t*) 0x40020020
+#define USART_SR    (volatile uint32_t*) 0x40004400
+#define USART_DR    (volatile uint32_t*) 0x40004404
+#define USART_BRR   (volatile uint32_t*) 0x40004408
+#define USART_CR1   (volatile uint32_t*) 0x4000440c
+#define USART_CR2   (volatile uint32_t*) 0x40004410
+#define USART_CR3   (volatile uint32_t*) 0x40004414
+
+// CR1 bits
+#define UE 13 //UART enable
+#define TE 3  // Transmitter enable
+#define RE 2  // Receiver enable
+
+// Status register bits
+#define TXE 7  // Transmit register empty
+#define RXNE 5  // Receive register is not empty..char received
+
+// Function prototypes
+extern void init_usart2(uint32_t baud, uint32_t sysclk);
+extern char usart2_getch();
+extern void usart2_putch(char c);
+
+#endif /* UART_DRIVER_H_ */

--- a/src/Manchester_State.c
+++ b/src/Manchester_State.c
@@ -1,0 +1,59 @@
+/*
+ * Manchester_State.c
+ *
+ *  Created on: Oct 6, 2018
+ *      Author: larsonma
+ */
+
+#include "Manchester_State.h"
+
+static uint8_t RX;
+static volatile EXTI *EXTI0 = (EXTI *) 0x40013C00;
+static volatile GPIOx *GPIOC = (GPIOx *) 0x40020800;
+
+static volatile enum STATES state;
+
+void init_state(){
+	state = IDLE;
+	RX = 1;
+
+	//start channel interrupt and timer interrupt
+	init_RX_channel();
+	init_interrupt_timer();
+}
+
+enum STATES getState(){
+	return state;
+}
+
+//Timer has expired
+void TIM2_IRQHandler(void){
+	//Set state according to what was previously captured
+	if(RX == 0){
+		state = COLLISION;
+	}else{
+		state = IDLE;
+	}
+
+	RX = (GPIOC -> IDR) & (1 << 0);
+
+	//clear flag
+	*(TIM2_SR) &= ~(1<<2);
+}
+
+//Edge Has Occured
+void EXTI0_IRQHandler(void){
+	//Set the Timer count to original value
+	*(TIM2_CNT) = 0;
+
+	//set the state to BUSY
+	state = BUSY;
+
+	//capture RX
+	RX = (GPIOC -> IDR) & (1 << 0);
+
+	//clear the status bits for the timer and RX
+	*(TIM2_SR) &= ~(1<<2);
+	EXTI0 -> PR |= 1<<0;
+}
+

--- a/src/RX.c
+++ b/src/RX.c
@@ -1,0 +1,45 @@
+/*
+ * RX.c
+ *
+ *  Created on: Oct 6, 2018
+ *      Author: larsonma
+ */
+
+#include "RX.h"
+
+static volatile EXTI *EXTI0 = (EXTI *) 0x40013C00;
+
+
+void init_RX_channel(){
+	//Setup PC0 on the GPIO ports
+
+	//Enable GPIO clock
+	enable_clock('C');
+
+	//Set to input mode
+	set_pin_mode('C', 0, INPUT);
+
+	//Enable SYSCFGEN
+	(*APB2ENR) |= 1<<14;
+
+	//Set port A for SYSCFG
+	(*EXTICR1) &= ~(0b1111);
+	(*EXTICR1) |= 0b0010;
+
+	//Enable EXTI interrupt
+	EXTI0->IMR |= 1<<0;
+
+	//Enable interrupt on rising edge
+	EXTI0->RTSR |= 1<<0;
+
+	//Enable interrupt on falling edge
+	EXTI0->FTSR |= 1<<0;
+
+	//PC0 is connected to EXTI0
+	//enable in NVIC
+	*(NVIC_ISER0) |= 1<<6;
+
+	//Set the pin to a lower priority
+	*(NVIC_IPR1) |= (0xFF << 16);
+}
+

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -1,0 +1,364 @@
+/*
+ * gpio.c
+ *
+ *  Created on: Dec 16, 2016
+ *      Author: larsonma
+ *  This is an API designed to make GPIO initialization and modification easy to
+ *  use, while minimizing risk of mistakes. Currently works for ports A,B, and C
+ */
+ 
+#include "gpio.h"
+
+static volatile GPIOx *GPIOA = (GPIOx *) 0x40020000;
+static volatile GPIOx *GPIOB = (GPIOx *) 0x40020400;
+static volatile GPIOx *GPIOC = (GPIOx *) 0x40020800;
+
+static void set_low_reg_alt_func(char port, uint8_t pin, uint8_t altFunc);
+static void set_high_reg_alt_func(char port, uint8_t pin,uint8_t altFunc);
+static volatile GPIOx* assignPort(char port);
+
+/*
+ * The function allows the clock for a specific GPIO port to be initialized. The port to
+ * be specified is not case sensitive.
+ * Inputs:
+ * 		char port - port to enable clock for
+ * Outputs:
+ * 		none
+ */
+void enable_clock(char port){
+	switch(port){
+		case 'A':
+		case 'a':
+			*(RCC_AHB1ENR) |= (1<<GPIOA_RCCEN_F);
+			break;
+		case 'B':
+		case 'b':
+			*(RCC_AHB1ENR) |= (1<<GPIOB_RCCEN_F);
+			break;
+		case 'C':
+		case 'c':
+			*(RCC_AHB1ENR) |= (1<<GPIOC_RCCEN_F);
+			break;			
+	}
+}
+
+/*
+ * This function allows a user to set any pin on a port to one of the 4 modes. The modes
+ * are specified by enumerated types INPUT, OUTPUT, ALTFUNC, and ANALOG. Protection against
+ * setting invalid pins is implemented.
+ * Inputs:
+ * 		char port - port to modify pins on
+ * 		uint8_t pin - pin to be modified
+ * 		Mode mode - mode to set pin to.
+ * Outputs:
+ * 		none
+ */
+void set_pin_mode(char port, uint8_t pin, Mode mode){
+	if(pin >=0 && pin <= 15){
+		volatile GPIOx* portX = assignPort(port);
+		
+		//check to see if port is null
+		if(!portX) return;
+		
+		//clear pins associated with pin mode
+		portX->MODER &= ~(0b11<<(pin*2));
+		
+		//set pin according to MODE specified
+		switch(mode){
+			case INPUT:
+				portX->MODER |= (0b00<<(pin*2));
+				break;
+			case OUTPUT:
+				portX->MODER |= (0b01<<(pin*2));
+				break;
+			case ALTFUNC:
+				portX->MODER |= (0b10<<(pin*2));
+				break;
+			case ANALOG:
+				portX->MODER |= (0b11<<(pin*2));
+				break;
+			default:
+				return;
+		}
+	}
+}
+
+/*
+ * This function allows a user to set any pin on a port to one of the 2 output types. The types
+ * are specified by enumerated types PULLUP and OPEN_DRAIN. Protection against
+ * setting invalid pins is implemented.
+ * Inputs:
+ * 		char port - port to modify pins on
+ * 		uint8_t pin - pin to be modified
+ * 		OutputType outtype - type to set pin to.
+ * Outputs:
+ * 		none
+ */
+void set_pin_output_type(char port, uint8_t pin, OutputType outtype){
+	if(pin >= 0 && pin <= 15){
+		volatile GPIOx* portX = assignPort(port);
+		
+		//check to see if port is null
+		if(!portX) return;
+
+		//clear pin specified
+		portX->OTYPER &= ~(1<<pin);
+
+		//switch output type of pin to type specified.
+		switch(outtype){
+			case PUSH_PULL:
+				portX->OTYPER |= (0<<pin);
+				break;
+			case OPEN_DRAIN:
+				portX->OTYPER |= (1<<pin);
+				break;
+			default:
+				return;
+		}
+	}		
+}
+
+/*
+ * This function allows a user to set any pin on a port to one of the 4 speeds. The speeds
+ * are specified by enumerated types LOW, MED, FAST, and HIGH. Protection against
+ * setting invalid pins is implemented.
+ * Inputs:
+ * 		char port - port to modify pins on
+ * 		uint8_t pin - pin to be modified
+ * 		Speed speed - speed to set pin to.
+ * Outputs:
+ * 		none
+ */
+void set_output_speed(char port, uint8_t pin, Speed speed){
+	if(pin >= 0 && pin <= 15){
+		volatile GPIOx* portX = assignPort(port);
+		
+		//check to see if port is null
+		if(!portX) return;
+
+		//clear speed set at specified pin
+		portX->OSPEEDR &= ~(0b11<<(pin*2));
+
+		//set pin to specified speed
+		switch(speed){
+			case LOW:
+				portX->OSPEEDR |= (0b00<<(pin*2));
+				break;
+			case MED:
+				portX->OSPEEDR |= (0b01<<(pin*2));
+				break;
+			case FAST:
+				portX->OSPEEDR |= (0b10<<(pin*2));
+				break;
+			case HIGH:
+				portX->OSPEEDR |= (0b11<<(pin*2));
+				break;
+			default:
+				return;
+		}
+	}		
+}
+
+/*
+ * This function allows a user to set any pin on a port to one of the 3 pull types. The types
+ * are specified by enumerated types NONE, PULLUP, and PULLDOWN. Protection against
+ * setting invalid pins is implemented.
+ * Inputs:
+ * 		char port - port to modify pins on
+ * 		uint8_t pin - pin to be modified
+ * 		PullType pulltype - pulltype to set pin to.
+ * Outputs:
+ * 		none
+ */
+void set_pin_PUPDR(char port, uint8_t pin, PullType pulltype){
+	if(pin >= 0 && pin <= 15){
+		volatile GPIOx* portX = assignPort(port);
+		
+		//check to see if portX is null
+		if(!portX) return;
+
+		//clear pull type set at specified pin
+		portX->PUPDR &= ~(0b11<<(pin*2));
+
+		//set pin the the specified pull type
+		switch(pulltype){
+			case NONE:
+				portX->PUPDR |= (0b00<<(pin*2));
+				break;
+			case PULLUP:
+				portX->PUPDR |= (0b01<<(pin*2));
+				break;
+			case PULLDOWN:
+				portX->PUPDR |= (0b10<<(pin*2));
+				break;
+			default:
+				return;
+		}
+	}		
+}
+
+/*
+ * This function allows a user to set any pin on a port to one of the 15 alternate modes. The modes
+ * are specified by their respective number specified in the programmers manual. Protection against
+ * setting invalid pins is implemented.
+ * Inputs:
+ * 		char port - port to modify pins on
+ * 		uint8_t pin - pin to be modified
+ * 		uint8_t altFunc - alternate function to set pin to.
+ * Outputs:
+ * 		none
+ */
+void set_alt_func(char port, uint8_t pin, uint8_t altFunc){
+	if(pin >= 0 && pin <=7){
+		set_low_reg_alt_func(port,pin,altFunc);		//if pin corresponds to pin 0-7, use the alternate function low register
+	}else if(pin >=8 && pin <= 15){
+		set_high_reg_alt_func(port,pin,altFunc);	//if pin corresponds to pin 8-15, use the alternate function high register
+	}else{
+		return;
+	}
+}
+
+static void set_low_reg_alt_func(char port, uint8_t pin, uint8_t altFunc){
+	volatile GPIOx* portX = assignPort(port);
+		
+	//check to see if port is null
+	if(!portX) return;
+			
+	portX->AFRL &= ~(0b1111<<(pin*4));
+
+	switch(altFunc){
+		case 0:
+			portX->AFRL |= (0b0000<<(pin*4));
+			break;
+		case 1:
+			portX->AFRL |= (0b0001<<(pin*4));
+			break;
+		case 2:
+			portX->AFRL |= (0b0010<<(pin*4));
+			break;
+		case 3:
+			portX->AFRL |= (0b0011<<(pin*4));
+			break;
+		case 4:
+			portX->AFRL |= (0b0100<<(pin*4));
+			break;
+		case 5:
+			portX->AFRL |= (0b0101<<(pin*4));
+			break;
+		case 6:
+			portX->AFRL |= (0b0110<<(pin*4));
+			break;
+		case 7:
+			portX->AFRL |= (0b0111<<(pin*4));
+			break;
+		case 8:
+			portX->AFRL |= (0b1000<<(pin*4));
+			break;
+		case 9:
+			portX->AFRL |= (0b1001<<(pin*4));
+			break;
+		case 10:
+			portX->AFRL |= (0b1010<<(pin*4));
+			break;
+		case 11:
+			portX->AFRL |= (0b1011<<(pin*4));
+			break;
+		case 12:
+			portX->AFRL |= (0b1100<<(pin*4));
+			break;
+		case 13:
+			portX->AFRL |= (0b1101<<(pin*4));
+			break;
+		case 14:
+			portX->AFRL |= (0b1110<<(pin*4));
+			break;
+		case 15:
+			portX->AFRL |= (0b1111<<(pin*4));
+			break;
+		default:
+			return;
+	}
+}
+
+static void set_high_reg_alt_func(char port, uint8_t pin,uint8_t altFunc){
+	pin -= 8;
+	
+	volatile GPIOx* portX = assignPort(port);
+		
+	//check to see if port is null
+	if(!portX) return;
+				
+	portX->AFRH &= ~(0b1111<<(pin*4));
+
+	switch(altFunc){
+		case 0:
+			portX->AFRH |= (0b0000<<(pin*4));
+			break;
+		case 1:
+			portX->AFRH |= (0b0001<<(pin*4));
+			break;
+		case 2:
+			portX->AFRH |= (0b0010<<(pin*4));
+			break;
+		case 3:
+			portX->AFRH |= (0b0011<<(pin*4));
+			break;
+		case 4:
+			portX->AFRH |= (0b0100<<(pin*4));
+			break;
+		case 5:
+			portX->AFRH |= (0b0101<<(pin*4));
+			break;
+		case 6:
+			portX->AFRH |= (0b0110<<(pin*4));
+			break;
+		case 7:
+			portX->AFRH |= (0b0111<<(pin*4));
+			break;
+		case 8:
+			portX->AFRH |= (0b1000<<(pin*4));
+			break;
+		case 9:
+			portX->AFRH |= (0b1001<<(pin*4));
+			break;
+		case 10:
+			portX->AFRH |= (0b1010<<(pin*4));
+			break;
+		case 11:
+			portX->AFRH |= (0b1011<<(pin*4));
+			break;
+		case 12:
+			portX->AFRH |= (0b1100<<(pin*4));
+			break;
+		case 13:
+			portX->AFRH |= (0b1101<<(pin*4));
+			break;
+		case 14:
+			portX->AFRH |= (0b1110<<(pin*4));
+			break;
+		case 15:
+			portX->AFRH |= (0b1111<<(pin*4));
+			break;
+		default:
+			return;
+	}
+}
+
+static volatile GPIOx* assignPort(char port){
+	switch(port){
+		case 'A':
+		case 'a':
+			return GPIOA;
+		case 'B':
+		case 'b':
+			return GPIOB;
+		case 'C':
+		case 'c':
+			return GPIOC;
+		default:
+			return NULL;		//error
+	}
+}
+
+
+

--- a/src/interrupt_timer.c
+++ b/src/interrupt_timer.c
@@ -1,0 +1,36 @@
+/*
+ * interrupt_timer.c
+ *
+ *  Created on: Oct 6, 2018
+ *      Author: larsonma
+ */
+
+#include "interrupt_timer.h"
+
+void init_interrupt_timer(){
+	//enable clock for TIM2
+	*(APB1ENR) |= 1;
+
+	//reload set to 1.11 ms
+	*(TIM2_ARR) = (17760-1);	// 1/16000000 * 17760 = 1.11ms
+
+	//compare to 1.11 ms
+	*(TIM2_CCR2) = (17760-1);
+
+	//select output mode (0b001)
+	*(TIM2_CCMR1) &= ~(0b111<<12);
+	*(TIM2_CCMR1) |= 0b001<<12;
+
+	//make OC2 signal an output on corresponding pin5
+	*(TIM2_CCER) |= 1<<4;
+
+	//enable interrupt
+	*(TIM2_DIER) |= 1<<2;
+
+	//enable in NVIC
+	*(NVIC_ISER0) |= 1<<28;
+
+	//enable the counter by setting CEN bit in CR1
+	*(TIM2_CR1) |= 1;
+
+}

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,69 @@
+/*
+ * main.c
+ *
+ *  Created on: Feb 17, 2017
+ *      Author: Mitchell Larson
+ * This is the main application for a system that monitors pedestrian
+ * traffic using an infared tripwire. The system can be set to one of
+ * 3 different modes. A scanning mode, an alarm mode, and an admin mode
+ */
+
+#include "Manchester_State.h"
+#include "gpio.h"
+
+static volatile GPIOx *GPIOC = (GPIOx *) 0x40020800;
+static void setLED(enum STATES state);
+
+/**
+ * The main function for this application runs a state machine, while
+ * periodically checking for a user entering the admin password. In
+ * order to perform tasks, many of the tasks are accomplished by
+ * calling static functions within this file
+ * Inputs:
+ * 		none
+ * Outputs:
+ * 		none
+ */
+int main(void){
+	init_state();
+
+	//GPIOC clock already selected
+	//set GPIOC pin 1,2,3 to output for LEDs
+	set_pin_mode('C', 1, OUTPUT);
+	set_pin_mode('C', 2, OUTPUT);
+	set_pin_mode('C', 3, OUTPUT);
+
+	enum STATES lastState = getState();
+	enum STATES currentState = getState();
+
+	setLED(currentState);
+
+	while(1==1){
+		currentState = getState();
+
+		if(currentState != lastState){
+			setLED(currentState);
+			lastState = currentState;
+		}
+	}
+
+	return 0;
+}
+
+static void setLED(enum STATES state){
+	GPIOC -> ODR &= ~(0b111 << 1);
+
+	switch(state){
+		case IDLE:
+			GPIOC -> ODR |= (0b001 << 1);
+			break;
+		case BUSY:
+			GPIOC -> ODR |= (0b010 << 1);
+			break;
+		case COLLISION:
+			GPIOC -> ODR |= (0b100 << 1);
+			break;
+		default:
+			break;
+	}
+}

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1,0 +1,222 @@
+/**
+*****************************************************************************
+**
+**  File        : syscalls.c
+**
+**  Abstract    : System Workbench Minimal System calls file
+**
+** 		          For more information about which c-functions
+**                need which of these lowlevel functions
+**                please consult the Newlib libc-manual
+**
+**  Environment : System Workbench for MCU
+**
+**  Distribution: The file is distributed “as is,” without any warranty
+**                of any kind.
+**
+*****************************************************************************
+**
+** <h2><center>&copy; COPYRIGHT(c) 2014 Ac6</center></h2>
+**
+** Redistribution and use in source and binary forms, with or without modification,
+** are permitted provided that the following conditions are met:
+**   1. Redistributions of source code must retain the above copyright notice,
+**      this list of conditions and the following disclaimer.
+**   2. Redistributions in binary form must reproduce the above copyright notice,
+**      this list of conditions and the following disclaimer in the documentation
+**      and/or other materials provided with the distribution.
+**   3. Neither the name of Ac6 nor the names of its contributors
+**      may be used to endorse or promote products derived from this software
+**      without specific prior written permission.
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+** AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+** IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+** FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+** DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+** CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+** OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+*****************************************************************************
+*/
+
+/***************************************************************************
+ * Made the following modifications in order to get stdio to work:
+ * 	1. Modified _read function to get correct behavior of fgets
+ * 	2. Commented out the _sbrk function since it will be redefined in sysmem.c
+ * 	3. Commented out lines from original implementation
+ */
+
+/* Includes */
+#include <sys/stat.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+#include <signal.h>
+#include <time.h>
+#include <sys/time.h>
+#include <sys/times.h>
+
+#include "uart_driver.h"
+
+/* Variables */
+//#undef errno
+extern int errno;
+//extern int __io_putchar(int ch) __attribute__((weak));
+//extern int __io_getchar(void) __attribute__((weak));
+
+register char * stack_ptr asm("sp");
+
+char *__env[1] = { 0 };
+char **environ = __env;
+
+
+/* Functions */
+void initialise_monitor_handles()
+{
+}
+
+int _getpid(void)
+{
+	return 1;
+}
+
+int _kill(int pid, int sig)
+{
+	errno = EINVAL;
+	return -1;
+}
+
+void _exit (int status)
+{
+	_kill(status, -1);
+	while (1) {}		/* Make sure we hang here */
+}
+
+int _read (int file, char *ptr, int len)
+{
+	int DataIdx;
+// Modified the for loop in order to get the correct behavior for fgets
+	int byteCnt = 0;
+	for (DataIdx = 0; DataIdx < len; DataIdx++)
+	{
+		//*ptr++ = __io_getchar();
+		byteCnt++;
+		//*ptr++ = usart2_getch();
+		*ptr = usart2_getch();
+		if(*ptr == '\n') break;
+		ptr++;
+	}
+
+//return len;
+	return byteCnt; // Return byte count
+}
+
+int _write(int file, char *ptr, int len)
+{
+	int DataIdx;
+
+	for (DataIdx = 0; DataIdx < len; DataIdx++)
+	{
+		//__io_putchar(*ptr++);
+		usart2_putch(*ptr++);
+	}
+	return len;
+}
+
+// Comment out _sbrk to avoid redefinition by sysmem.c
+/*
+caddr_t _sbrk(int incr)
+{
+	extern char end asm("end");
+	static char *heap_end;
+	char *prev_heap_end;
+
+	if (heap_end == 0)
+		heap_end = &end;
+
+	prev_heap_end = heap_end;
+	if (heap_end + incr > stack_ptr)
+	{
+//		write(1, "Heap and stack collision\n", 25);
+//		abort();
+		errno = ENOMEM;
+		return (caddr_t) -1;
+	}
+
+	heap_end += incr;
+
+	return (caddr_t) prev_heap_end;
+}
+*/
+int _close(int file)
+{
+	return -1;
+}
+
+
+int _fstat(int file, struct stat *st)
+{
+	st->st_mode = S_IFCHR;
+	return 0;
+}
+
+int _isatty(int file)
+{
+	return 1;
+}
+
+int _lseek(int file, int ptr, int dir)
+{
+	return 0;
+}
+
+int _open(char *path, int flags, ...)
+{
+	/* Pretend like we always fail */
+	return -1;
+}
+
+int _wait(int *status)
+{
+	errno = ECHILD;
+	return -1;
+}
+
+int _unlink(char *name)
+{
+	errno = ENOENT;
+	return -1;
+}
+
+int _times(struct tms *buf)
+{
+	return -1;
+}
+
+int _stat(char *file, struct stat *st)
+{
+	st->st_mode = S_IFCHR;
+	return 0;
+}
+
+int _link(char *old, char *new)
+{
+	errno = EMLINK;
+	return -1;
+}
+
+int _fork(void)
+{
+	errno = EAGAIN;
+	return -1;
+}
+
+int _execve(char *name, char **argv, char **env)
+{
+	errno = ENOMEM;
+	return -1;
+}

--- a/src/uart_driver.c
+++ b/src/uart_driver.c
@@ -1,0 +1,57 @@
+/*
+ * uart_driver.c
+ *
+ *  Created on: Nov 8, 2016
+ *      Author: barnekow
+ */
+#include "uart_driver.h"
+#include <inttypes.h>
+#include <stdio.h>
+
+char usart2_getch(){
+	char c;
+	while((*(USART_SR)&(1<<RXNE)) != (1<<RXNE));
+	c = ((char) *USART_DR);  // Read character from usart
+	usart2_putch(c);  // Echo back
+
+	if (c == '\r'){  // If character is CR
+		usart2_putch('\n');  // send it
+		c = '\n';   // Return LF. fgets is terminated by LF
+	}
+
+	return c;
+}
+
+void usart2_putch(char c){
+	while((*(USART_SR)&(1<<TXE)) != (1<<TXE));
+	*(USART_DR) = c;
+}
+
+void init_usart2(uint32_t baud, uint32_t sysclk){
+	// Enable clocks for GPIOA and USART2
+	*(RCC_AHB1ENR) |= (1<<GPIOAEN);
+	*(RCC_APB1ENR) |= (1<<USART2EN);
+
+	// Function 7 of PORTA pins is USART
+	*(GPIOA_AFRL) &= (0xFFFF00FF); // Clear the bits associated with PA3 and PA2
+	*(GPIOA_AFRL) |= (0b01110111<<8);  // Choose function 7 for both PA3 and PA2
+	*(GPIOA_MODER) &= (0xFFFFFF0F);  // Clear mode bits for PA3 and PA2
+	*(GPIOA_MODER) |= (0b1010<<4);  // Both PA3 and PA2 in alt function mode
+
+	// Set up USART2
+	//USART2_init();  //8n1 no flow control
+	// over8 = 0..oversample by 16
+	// M = 0..1 start bit, data size is 8, 1 stop bit
+	// PCE= 0..Parity check not enabled
+	// no interrupts... using polling
+	*(USART_CR1) = (1<<UE)|(1<<TE)|(1<<RE); // Enable UART, Tx and Rx
+	*(USART_CR2) = 0;  // This is the default, but do it anyway
+	*(USART_CR3) = 0;  // This is the default, but do it anyway
+	*(USART_BRR) = sysclk/baud;
+
+	/* I'm not sure if this is needed for standard IO*/
+	 //setvbuf(stderr, NULL, _IONBF, 0);
+	 //setvbuf(stdin, NULL, _IONBF, 0);
+	 setvbuf(stdout, NULL, _IONBF, 0);
+}
+

--- a/startup/startup_stm32.s
+++ b/startup/startup_stm32.s
@@ -1,0 +1,455 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32.s
+  * @author    Ac6
+  * @version   V1.0.0
+  * @date      12-June-2014
+  ******************************************************************************
+  */
+
+/*
+   Modified by Darrin Rothe to enable floating point in the reset handler and
+   to add weakly defined IRQ vectors.
+*/
+	
+  .syntax unified
+  .cpu cortex-m4
+  .thumb
+
+.global	g_pfnVectors
+.global	Default_Handler
+
+/* start address for the initialization values of the .data section.
+defined in linker script */
+.word	_sidata
+/* start address for the .data section. defined in linker script */
+.word	_sdata
+/* end address for the .data section. defined in linker script */
+.word	_edata
+/* start address for the .bss section. defined in linker script */
+.word	_sbss
+/* end address for the .bss section. defined in linker script */
+.word	_ebss
+
+.equ  BootRAM,        0xF1E0F85F
+/**
+ * @brief  This is the code that gets called when the processor first
+ *          starts execution following a reset event. Only the absolutely
+ *          necessary set is performed, after which the application
+ *          supplied main() routine is called.
+ * @param  None
+ * @retval : None
+*/
+
+    .section	.text.Reset_Handler
+	.weak	Reset_Handler
+	.type	Reset_Handler, %function
+Reset_Handler:
+
+// enable floating point - added by DER
+
+	# CPACR is located at address 0xE000ED88
+	LDR.W   R0, =0xE000ED88
+	# Read CPACR
+	LDR R1, [R0]
+	# Set bits 20-23 to enable CP10 and CP11 coprocessors
+	ORR R1, R1, #(0xF << 20)
+	# Write back the modified value to the CPACR
+	STR R1, [R0] // wait for store to complete
+	DSB
+	# reset pipeline now the FPU is enabled
+	ISB
+
+/* Copy the data segment initializers from flash to SRAM */
+  movs	r1, #0
+  b	LoopCopyDataInit
+
+CopyDataInit:
+	ldr	r3, =_sidata
+	ldr	r3, [r3, r1]
+	str	r3, [r0, r1]
+	adds	r1, r1, #4
+
+LoopCopyDataInit:
+	ldr	r0, =_sdata
+	ldr	r3, =_edata
+	adds	r2, r0, r1
+	cmp	r2, r3
+	bcc	CopyDataInit
+	ldr	r2, =_sbss
+	b	LoopFillZerobss
+/* Zero fill the bss segment. */
+FillZerobss:
+	movs r3, #0
+ 	str  r3, [r2]
+	adds r2, r2, #4
+
+LoopFillZerobss:
+	ldr	r3, = _ebss
+	cmp	r2, r3
+	bcc	FillZerobss
+
+/* Call the clock system intitialization function.*/
+    bl  SystemInit
+/* Call static constructors */
+    bl __libc_init_array
+/* Call the application's entry point.*/
+	bl	main
+
+LoopForever:
+    b LoopForever
+
+.size	Reset_Handler, .-Reset_Handler
+
+/**
+ * @brief  This is the code that gets called when the processor receives an
+ *         unexpected interrupt.  This simply enters an infinite loop, preserving
+ *         the system state for examination by a debugger.
+ *
+ * @param  None
+ * @retval : None
+*/
+    .section	.text.Default_Handler,"ax",%progbits
+Default_Handler:
+Infinite_Loop:
+	b	Infinite_Loop
+	.size	Default_Handler, .-Default_Handler
+/******************************************************************************
+*
+* The minimal vector table for a Cortex-M.  Note that the proper constructs
+* must be placed on this to ensure that it ends up at physical address
+* 0x0000.0000.
+*
+******************************************************************************/
+ 	.section	.isr_vector,"a",%progbits
+	.type	g_pfnVectors, %object
+	.size	g_pfnVectors, .-g_pfnVectors
+
+g_pfnVectors:
+	.word	_estack
+	.word	Reset_Handler
+	.word	NMI_Handler
+	.word	HardFault_Handler
+	.word	MemManage_Handler
+	.word	BusFault_Handler
+	.word	UsageFault_Handler
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	SVC_Handler
+	.word	DebugMon_Handler
+	.word	0
+	.word	PendSV_Handler
+	.word	SysTick_Handler
+	.word	WWDG_IRQHandler                   // Window WatchDog
+    .word	PVD_IRQHandler                 // PVD through EXTI Line detection
+    .word	TAMP_STAMP_IRQHandler             // Tamper and TimeStamps through the EXTI line
+    .word	RTC_WKUP_IRQHandler               // RTC Wakeup through the EXTI line
+    .word	FLASH_IRQHandler                 // FLASH
+    .word	RCC_IRQHandler                    // RCC
+    .word	EXTI0_IRQHandler                 // EXTI Line0
+    .word	EXTI1_IRQHandler                  // EXTI Line1
+    .word	EXTI2_IRQHandler                  // EXTI Line2
+    .word	EXTI3_IRQHandler                  // EXTI Line3
+    .word	EXTI4_IRQHandler                  // EXTI Line4
+    .word	DMA1_Stream0_IRQHandler           // DMA1 Stream 0
+    .word	DMA1_Stream1_IRQHandler           // DMA1 Stream 1
+    .word	DMA1_Stream2_IRQHandler           // DMA1 Stream 2
+    .word	DMA1_Stream3_IRQHandler           // DMA1 Stream 3
+    .word	DMA1_Stream4_IRQHandler           // DMA1 Stream 4
+    .word	DMA1_Stream5_IRQHandler           // DMA1 Stream 5
+    .word	DMA1_Stream6_IRQHandler           // DMA1 Stream 6
+    .word	ADC_IRQHandler                    // ADC1, ADC2 and ADC3s
+    .word	CAN1_TX_IRQHandler                // CAN1 TX
+    .word	CAN1_RX0_IRQHandler               // CAN1 RX0
+    .word	CAN1_RX1_IRQHandler               // CAN1 RX1
+    .word	CAN1_SCE_IRQHandler               // CAN1 SCE
+    .word	EXTI9_5_IRQHandler                // External Line[9:5]s
+    .word	TIM1_BRK_TIM9_IRQHandler          // TIM1 Break and TIM9
+    .word	TIM1_UP_TIM10_IRQHandler          // TIM1 Update and TIM10
+    .word	TIM1_TRG_COM_TIM11_IRQHandler     // TIM1 Trigger and Commutation and TIM11
+    .word	TIM1_CC_IRQHandler                // TIM1 Capture Compare
+    .word	TIM2_IRQHandler                   // TIM2
+    .word	TIM3_IRQHandler                   // TIM3
+    .word	TIM4_IRQHandler                   // TIM4
+    .word	I2C1_EV_IRQHandler                // I2C1 Event
+    .word	I2C1_ER_IRQHandler                // I2C1 Error
+    .word	I2C2_EV_IRQHandler                // I2C2 Event
+    .word	I2C2_ER_IRQHandler                // I2C2 Error
+    .word	SPI1_IRQHandler                   // SPI1
+    .word	SPI2_IRQHandler                   // SPI2
+    .word	USART1_IRQHandler                 // USART1
+    .word	USART2_IRQHandler                 // USART2
+    .word	USART3_IRQHandler                 // USART3
+    .word	EXTI15_10_IRQHandler              // External Line[15:10]s
+    .word	RTC_Alarm_IRQHandler              // RTC Alarm (A and B) through EXTI Line
+    .word	OTG_FS_WKUP_IRQHandler            // USB OTG FS Wakeup through EXTI line
+    .word	TIM8_BRK_TIM12_IRQHandler         // TIM8 Break and TIM12
+    .word	TIM8_UP_TIM13_IRQHandler          // TIM8 Update and TIM13
+    .word	TIM8_TRG_COM_TIM14_IRQHandler     // TIM8 Trigger and Commutation and TIM14
+    .word	TIM8_CC_IRQHandler                // TIM8 Capture Compare
+    .word	DMA1_Stream7_IRQHandler           // DMA1 Stream7
+    .word	FMC_IRQHandler                    // FMC
+    .word	SDIO_IRQHandler                   // SDIO
+    .word	TIM5_IRQHandler                   // TIM5
+    .word	SPI3_IRQHandler                   // SPI3
+    .word	UART4_IRQHandler                  // UART4
+    .word	UART5_IRQHandler                  // UART5
+    .word	TIM6_DAC_IRQHandler               // TIM6 and DAC1&2 underrun errors
+    .word	TIM7_IRQHandler                   // TIM7
+    .word	DMA2_Stream0_IRQHandler           // DMA2 Stream 0
+    .word	DMA2_Stream1_IRQHandler           // DMA2 Stream 1
+    .word	DMA2_Stream2_IRQHandler           // DMA2 Stream 2
+    .word	DMA2_Stream3_IRQHandler           // DMA2 Stream 3
+    .word	DMA2_Stream4_IRQHandler           // DMA2 Stream 4
+    .word	0                                 // Reserved
+    .word	0                                 // Reserved
+    .word	CAN2_TX_IRQHandler                // CAN2 TX
+    .word	CAN2_RX0_IRQHandler               // CAN2 RX0
+    .word	CAN2_RX1_IRQHandler               // CAN2 RX1
+    .word	CAN2_SCE_IRQHandler               // CAN2 SCE
+    .word	OTG_FS_IRQHandler                 // USB OTG FS
+    .word	DMA2_Stream5_IRQHandler           // DMA2 Stream 5
+    .word	DMA2_Stream6_IRQHandler           // DMA2 Stream 6
+    .word	DMA2_Stream7_IRQHandler           // DMA2 Stream 7
+    .word	USART6_IRQHandler                 // USART6
+    .word	I2C3_EV_IRQHandler                // I2C3 event
+    .word	I2C3_ER_IRQHandler                // I2C3 error
+    .word	OTG_HS_EP1_OUT_IRQHandler         // USB OTG HS End Point 1 Out
+    .word	OTG_HS_EP1_IN_IRQHandler          // USB OTG HS End Point 1 In
+    .word	OTG_HS_WKUP_IRQHandler            // USB OTG HS Wakeup through EXTI
+    .word	OTG_HS_IRQHandler                 // USB OTG HS
+    .word	DCMI_IRQHandler                   // DCMI
+    .word	0                                 // Reserved
+    .word	0                                 // Reserved
+    .word	FPU_IRQHandler                    // FPU
+    .word	0                                 // Reserved
+    .word	0                                 // Reserved
+    .word	SPI4_IRQHandler                   // SPI4
+    .word	0                                 // Reserved
+    .word	0                                 // Reserved
+    .word	SAI1_IRQHandler                   // SAI1
+    .word	0                                 // Reserved
+    .word	0                                 // Reserved
+    .word	0                                 // Reserved
+    .word	SAI2_IRQHandler                   // SAI2
+    .word	QUADSPI_IRQHandler                // QuadSPI
+    .word	HDMI_CEC_IRQHandler                    // CEC
+    .word	SPDIF_RX_IRQHandler               // SPDIF RX
+    .word	FMPI2C1_IRQHandler             // FMPI2C1 Event
+    .word	FMPI2C1_Error_IRQHandler             // FMPI2C1 Error
+
+/*******************************************************************************
+*
+* Provide weak aliases for each Exception handler to the Default_Handler.
+* As they are weak aliases, any function with the same name will override
+* this definition.
+*
+*******************************************************************************/
+
+  	.weak	NMI_Handler
+	.thumb_set NMI_Handler,Default_Handler
+
+  	.weak	HardFault_Handler
+	.thumb_set HardFault_Handler,Default_Handler
+
+  	.weak	MemManage_Handler
+	.thumb_set MemManage_Handler,Default_Handler
+
+  	.weak	BusFault_Handler
+	.thumb_set BusFault_Handler,Default_Handler
+
+	.weak	UsageFault_Handler
+	.thumb_set UsageFault_Handler,Default_Handler
+
+	.weak	SVC_Handler
+	.thumb_set SVC_Handler,Default_Handler
+
+	.weak	DebugMon_Handler
+	.thumb_set DebugMon_Handler,Default_Handler
+
+	.weak	PendSV_Handler
+	.thumb_set PendSV_Handler,Default_Handler
+
+	.weak	SysTick_Handler
+	.thumb_set SysTick_Handler,Default_Handler
+
+	.weak	WWDG_IRQHandler
+    .weak	PVD_IRQHandler
+    .weak	TAMP_STAMP_IRQHandler
+    .weak	RTC_WKUP_IRQHandler
+    .weak	FLASH_IRQHandler
+    .weak	RCC_IRQHandler
+    .weak	EXTI0_IRQHandler
+    .weak	EXTI1_IRQHandler
+    .weak	EXTI2_IRQHandler
+    .weak	EXTI3_IRQHandler
+    .weak	EXTI4_IRQHandler
+    .weak	DMA1_Stream0_IRQHandler
+    .weak	DMA1_Stream1_IRQHandler
+    .weak	DMA1_Stream2_IRQHandler
+    .weak	DMA1_Stream3_IRQHandler
+    .weak	DMA1_Stream4_IRQHandler
+    .weak	DMA1_Stream5_IRQHandler
+    .weak	DMA1_Stream6_IRQHandler
+    .weak	ADC_IRQHandler
+    .weak	CAN1_TX_IRQHandler
+    .weak	CAN1_RX0_IRQHandler
+    .weak	CAN1_RX1_IRQHandler
+    .weak	CAN1_SCE_IRQHandler
+    .weak	EXTI9_5_IRQHandler
+    .weak	TIM1_BRK_TIM9_IRQHandler
+    .weak	TIM1_UP_TIM10_IRQHandler
+    .weak	TIM1_TRG_COM_TIM11_IRQHandler
+    .weak	TIM1_CC_IRQHandler
+    .weak	TIM2_IRQHandler
+    .weak	TIM3_IRQHandler
+    .weak	TIM4_IRQHandler
+    .weak	I2C1_EV_IRQHandler
+    .weak	I2C1_ER_IRQHandler
+    .weak	I2C2_EV_IRQHandler
+    .weak	I2C2_ER_IRQHandler
+    .weak	SPI1_IRQHandler
+    .weak	SPI2_IRQHandler
+    .weak	USART1_IRQHandler
+    .weak	USART2_IRQHandler
+    .weak	USART3_IRQHandler
+    .weak	EXTI15_10_IRQHandler
+    .weak	RTC_Alarm_IRQHandler
+    .weak	OTG_FS_WKUP_IRQHandler
+    .weak	TIM8_BRK_TIM12_IRQHandler
+    .weak	TIM8_UP_TIM13_IRQHandler
+    .weak	TIM8_TRG_COM_TIM14_IRQHandler
+    .weak	TIM8_CC_IRQHandler
+    .weak	DMA1_Stream7_IRQHandler
+    .weak	FMC_IRQHandler
+    .weak	SDIO_IRQHandler
+    .weak	TIM5_IRQHandler
+    .weak	SPI3_IRQHandler
+    .weak	UART4_IRQHandler
+    .weak	UART5_IRQHandler
+    .weak	TIM6_DAC_IRQHandler
+    .weak	TIM7_IRQHandler
+    .weak	DMA2_Stream0_IRQHandler
+    .weak	DMA2_Stream1_IRQHandler
+    .weak	DMA2_Stream2_IRQHandler
+    .weak	DMA2_Stream3_IRQHandler
+    .weak	DMA2_Stream4_IRQHandler
+    .weak	CAN2_TX_IRQHandler
+    .weak	CAN2_RX0_IRQHandler
+    .weak	CAN2_RX1_IRQHandler
+    .weak	CAN2_SCE_IRQHandler
+    .weak	OTG_FS_IRQHandler
+    .weak	DMA2_Stream5_IRQHandler
+    .weak	DMA2_Stream6_IRQHandler
+    .weak	DMA2_Stream7_IRQHandler
+    .weak	USART6_IRQHandler
+    .weak	I2C3_EV_IRQHandler
+    .weak	I2C3_ER_IRQHandler
+    .weak	OTG_HS_EP1_OUT_IRQHandler
+    .weak	OTG_HS_EP1_IN_IRQHandler
+    .weak	OTG_HS_WKUP_IRQHandler
+    .weak	OTG_HS_IRQHandler
+    .weak	DCMI_IRQHandler
+    .weak	FPU_IRQHandler
+    .weak	SPI4_IRQHandler
+    .weak	SAI1_IRQHandler
+    .weak	SAI2_IRQHandler
+    .weak	QUADSPI_IRQHandler
+    .weak	HDMI_CEC_IRQHandler
+    .weak	SPDIF_RX_IRQHandler
+    .weak	FMPI2C1_IRQHandler
+    .weak	FMPI2C1_Error_IRQHandler
+
+
+	.thumb_set WWDG_IRQHandler,Default_Handler
+    .thumb_set PVD_IRQHandler,Default_Handler
+    .thumb_set TAMP_STAMP_IRQHandler,Default_Handler
+    .thumb_set RTC_WKUP_IRQHandler,Default_Handler
+    .thumb_set FLASH_IRQHandler,Default_Handler
+    .thumb_set RCC_IRQHandler,Default_Handler
+    .thumb_set EXTI0_IRQHandler,Default_Handler
+    .thumb_set EXTI1_IRQHandler,Default_Handler
+    .thumb_set EXTI2_IRQHandler,Default_Handler
+    .thumb_set EXTI3_IRQHandler,Default_Handler
+    .thumb_set EXTI4_IRQHandler,Default_Handler
+    .thumb_set DMA1_Stream0_IRQHandler,Default_Handler
+    .thumb_set DMA1_Stream1_IRQHandler,Default_Handler
+    .thumb_set DMA1_Stream2_IRQHandler,Default_Handler
+    .thumb_set DMA1_Stream3_IRQHandler,Default_Handler
+    .thumb_set DMA1_Stream4_IRQHandler,Default_Handler
+    .thumb_set DMA1_Stream5_IRQHandler,Default_Handler
+    .thumb_set DMA1_Stream6_IRQHandler,Default_Handler
+    .thumb_set ADC_IRQHandler,Default_Handler
+    .thumb_set CAN1_TX_IRQHandler,Default_Handler
+    .thumb_set CAN1_RX0_IRQHandler,Default_Handler
+    .thumb_set CAN1_RX1_IRQHandler,Default_Handler
+    .thumb_set CAN1_SCE_IRQHandler,Default_Handler
+    .thumb_set EXTI9_5_IRQHandler,Default_Handler
+    .thumb_set TIM1_BRK_TIM9_IRQHandler,Default_Handler
+    .thumb_set TIM1_UP_TIM10_IRQHandler,Default_Handler
+    .thumb_set TIM1_TRG_COM_TIM11_IRQHandler,Default_Handler
+    .thumb_set TIM1_CC_IRQHandler,Default_Handler
+    .thumb_set TIM2_IRQHandler,Default_Handler
+    .thumb_set TIM3_IRQHandler,Default_Handler
+    .thumb_set TIM4_IRQHandler,Default_Handler
+    .thumb_set I2C1_EV_IRQHandler,Default_Handler
+    .thumb_set I2C1_ER_IRQHandler,Default_Handler
+    .thumb_set I2C2_EV_IRQHandler,Default_Handler
+    .thumb_set I2C2_ER_IRQHandler,Default_Handler
+    .thumb_set SPI1_IRQHandler,Default_Handler
+    .thumb_set SPI2_IRQHandler,Default_Handler
+    .thumb_set USART1_IRQHandler,Default_Handler
+    .thumb_set USART2_IRQHandler,Default_Handler
+    .thumb_set USART3_IRQHandler,Default_Handler
+    .thumb_set EXTI15_10_IRQHandler,Default_Handler
+    .thumb_set RTC_Alarm_IRQHandler,Default_Handler
+    .thumb_set OTG_FS_WKUP_IRQHandler,Default_Handler
+    .thumb_set TIM8_BRK_TIM12_IRQHandler,Default_Handler
+    .thumb_set TIM8_UP_TIM13_IRQHandler,Default_Handler
+    .thumb_set TIM8_TRG_COM_TIM14_IRQHandler,Default_Handler
+    .thumb_set TIM8_CC_IRQHandler,Default_Handler
+    .thumb_set DMA1_Stream7_IRQHandler,Default_Handler
+    .thumb_set FMC_IRQHandler,Default_Handler
+    .thumb_set SDIO_IRQHandler,Default_Handler
+    .thumb_set TIM5_IRQHandler,Default_Handler
+    .thumb_set SPI3_IRQHandler,Default_Handler
+    .thumb_set UART4_IRQHandler,Default_Handler
+    .thumb_set UART5_IRQHandler,Default_Handler
+    .thumb_set TIM6_DAC_IRQHandler,Default_Handler
+    .thumb_set TIM7_IRQHandler,Default_Handler
+    .thumb_set DMA2_Stream0_IRQHandler,Default_Handler
+    .thumb_set DMA2_Stream1_IRQHandler,Default_Handler
+    .thumb_set DMA2_Stream2_IRQHandler,Default_Handler
+    .thumb_set DMA2_Stream3_IRQHandler,Default_Handler
+    .thumb_set DMA2_Stream4_IRQHandler,Default_Handler
+    .thumb_set CAN2_TX_IRQHandler,Default_Handler
+    .thumb_set CAN2_RX0_IRQHandler,Default_Handler
+    .thumb_set CAN2_RX1_IRQHandler,Default_Handler
+    .thumb_set CAN2_SCE_IRQHandler,Default_Handler
+    .thumb_set OTG_FS_IRQHandler,Default_Handler
+    .thumb_set DMA2_Stream5_IRQHandler,Default_Handler
+    .thumb_set DMA2_Stream6_IRQHandler,Default_Handler
+    .thumb_set DMA2_Stream7_IRQHandler,Default_Handler
+    .thumb_set USART6_IRQHandler,Default_Handler
+    .thumb_set I2C3_EV_IRQHandler,Default_Handler
+    .thumb_set I2C3_ER_IRQHandler,Default_Handler
+    .thumb_set OTG_HS_EP1_OUT_IRQHandler,Default_Handler
+    .thumb_set OTG_HS_EP1_IN_IRQHandler,Default_Handler
+    .thumb_set OTG_HS_WKUP_IRQHandler,Default_Handler
+    .thumb_set OTG_HS_IRQHandler,Default_Handler
+    .thumb_set DCMI_IRQHandler,Default_Handler
+    .thumb_set FPU_IRQHandler,Default_Handler
+    .thumb_set SPI4_IRQHandler,Default_Handler
+    .thumb_set SAI1_IRQHandler,Default_Handler
+    .thumb_set SAI2_IRQHandler,Default_Handler
+    .thumb_set QUADSPI_IRQHandler,Default_Handler
+    .thumb_set HDMI_CEC_IRQHandler,Default_Handler
+    .thumb_set SPDIF_RX_IRQHandler,Default_Handler
+    .thumb_set FMPI2C1_IRQHandler,Default_Handler
+    .thumb_set FMPI2C1_Error_IRQHandler,Default_Handler
+
+	.weak	SystemInit
+
+/************************ (C) COPYRIGHT Ac6 *****END OF FILE****/

--- a/startup/sysmem.c
+++ b/startup/sysmem.c
@@ -1,0 +1,82 @@
+/**
+*****************************************************************************
+**
+**  File        : sysmem.c
+**
+**  Author	    : Ac6
+**
+**  Abstract    : System Workbench Minimal System Memory calls file
+**
+** 		          For more information about which c-functions
+**                need which of these lowlevel functions
+**                please consult the Newlib libc-manual
+**
+**  Environment : System Workbench for MCU
+**
+**  Distribution: The file is distributed “as is,” without any warranty
+**                of any kind.
+**
+*****************************************************************************
+**
+** <h2><center>&copy; COPYRIGHT(c) 2014 Ac6</center></h2>
+**
+** Redistribution and use in source and binary forms, with or without modification,
+** are permitted provided that the following conditions are met:
+**   1. Redistributions of source code must retain the above copyright notice,
+**      this list of conditions and the following disclaimer.
+**   2. Redistributions in binary form must reproduce the above copyright notice,
+**      this list of conditions and the following disclaimer in the documentation
+**      and/or other materials provided with the distribution.
+**   3. Neither the name of Ac6 nor the names of its contributors
+**      may be used to endorse or promote products derived from this software
+**      without specific prior written permission.
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+** AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+** IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+** FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+** DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+** CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+** OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+*****************************************************************************
+*/
+
+/* Includes */
+#include <errno.h>
+#include <stdio.h>
+
+/* Variables */
+extern int errno;
+register char * stack_ptr asm("sp");
+
+/* Functions */
+
+/**
+ _sbrk
+ Increase program data space. Malloc and related functions depend on this
+**/
+caddr_t _sbrk(int incr)
+{
+	extern char end asm("end");
+	static char *heap_end;
+	char *prev_heap_end;
+
+	if (heap_end == 0)
+		heap_end = &end;
+
+	prev_heap_end = heap_end;
+	if (heap_end + incr > stack_ptr)
+	{
+		errno = ENOMEM;
+		return (caddr_t) -1;
+	}
+
+	heap_end += incr;
+
+	return (caddr_t) prev_heap_end;
+}
+


### PR DESCRIPTION
@piparocj , here is an implementation of the channel monitor in C that I got to work. It's a little messy, but it will allow us to move forward for now. I created a new branch in the upstream repo called STM32, and I think we should merge our code into that repo for now on. Take a look at what I have (you can mostly ignore the *.h files, alot are carry over from previous projects that might be helpful), and let me know if you have any questions or concerns. This was tested, and it did not get into the incorrect states that we were observing with the DE0-Nano-SoC. 

This implementation uses GPIO pins PC0 for RX, PC1 for IDLE, PC2 for BUSY, and PC3 for COLLISION.