### PR TITLE
Add CRC functionality

### DIFF
--- a/inc/crc.h
+++ b/inc/crc.h
@@ -12,6 +12,10 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
+#define	CRC8_ELEMENTS	256					// Number of elements in a CRC8 lookup table
+#define CRC8_MASK		0x80				// CRC8 mask to test if it is the MSB
+#define BITS_PER_BYTE	8
+
 /*
  * Initialize the CRC by computing the CRC8 lookup table
  */

--- a/inc/crc.h
+++ b/inc/crc.h
@@ -1,0 +1,40 @@
+/*
+ * crc.h
+ *
+ *  Created on: Oct 24, 2018
+ *      Author: piparocj
+ */
+
+// Compiler guard
+#ifndef CRC_H
+#define CRC_H
+
+#include <inttypes.h>
+#include <stdbool.h>
+
+/*
+ * Initialize the CRC by computing the CRC8 lookup table
+ */
+extern void init_CRC();
+
+/*
+ * Take a message to transmit and calculate the CRC value to send
+ *
+ * @param data - The data of the message to transmit
+ * @param size - The number of bytes in 'data'
+ *
+ * @return - The value of the calculated CRC
+ */
+extern uint8_t encode_CRC(const char *data, uint8_t size);
+
+/*
+ * Take received data and determine if there were any errors through CRC
+ *
+ * @param data - The data that was received
+ * @param size - The number of bytes in 'data'
+ *
+ * @return - True if no errors, false if errors
+ */
+extern bool decode_CRC(const char *data, uint8_t size);
+
+#endif	// End compiler guard

--- a/inc/crc.h
+++ b/inc/crc.h
@@ -12,9 +12,9 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
-#define	CRC8_ELEMENTS	256					// Number of elements in a CRC8 lookup table
-#define CRC8_MASK		0x80				// CRC8 mask to test if it is the MSB
-#define BITS_PER_BYTE	8
+#define CRC8_ELEMENTS 256					// Number of elements in a CRC8 lookup table
+#define CRC8_MASK     0x80				// CRC8 mask to test if it is the MSB
+#define BITS_PER_BYTE 8
 
 /*
  * Initialize the CRC by computing the CRC8 lookup table

--- a/src/crc.c
+++ b/src/crc.c
@@ -16,7 +16,7 @@ static const uint16_t polynomial = 0x107; 		// x^8 + x^2 + x + 1 = 100000111 = 0
 static uint8_t crc_table[CRC8_ELEMENTS + 1];	// CRC8 lookup table
 
 // Helper function to calculate CRC
-static uint8_t calculate_crc(const char *data, uint8_t size);
+static uint8_t calculate_CRC(const char *data, uint8_t size);
 
 // Set up CRC lookup table
 void init_CRC()
@@ -26,15 +26,16 @@ void init_CRC()
 	{
 		uint8_t byte = (uint8_t)i;	// Byte to add to lookup table
 
-		// Iterate over every bit in a byte to calculate value to insert
+		// Iterate over every bit in a byte to calculate byte value to insert
 		for(uint8_t j = 0; j < NUM_BITS_PER_BYTE; j++)
 		{
 			byte <<= 1;
+		}
 
-			if(byte & CRC8_MASK)
-			{
-				byte ^= polynomial;
-			}
+		// Only XOR if it is the MSB is set
+		if(byte & CRC8_MASK)
+		{
+			byte ^= polynomial;
 		}
 
 		// Insert byte to lookup table
@@ -45,17 +46,18 @@ void init_CRC()
 // Calculate CRC to send
 uint8_t encode_CRC(const char *data, uint8_t size)
 {
-	return calculate_crc(data, size);
+	return calculate_CRC(data, size);
 }
 
 // Use CRC to detect if there were errors in received data
 bool decode_CRC(const char *data, uint8_t size)
 {
-	return !calculate_crc(data, size);
+	// Calculated CRC will return 0 if no errors
+	return !calculate_CRC(data, size);
 }
 
 // Helper function to calculate CRC
-uint8_t calculate_crc(const char *data, uint8_t size)
+uint8_t calculate_CRC(const char *data, uint8_t size)
 {
 	uint8_t crc = 0;
 

--- a/src/crc.c
+++ b/src/crc.c
@@ -1,0 +1,70 @@
+/*
+ * crc.c
+ *
+ *  Created on: Oct 24, 2018
+ *      Author: piparocj
+ */
+
+#include "crc.h"
+
+#define	CRC8_ELEMENTS		255					// Number of elements in a CRC8 lookup table
+#define CRC8_MASK			0x80				// CRC8 mask to test if it is the MSB
+#define NUM_BITS_PER_BYTE	8
+
+
+static const uint16_t polynomial = 0x107; 		// x^8 + x^2 + x + 1 = 100000111 = 0x107
+static uint8_t crc_table[CRC8_ELEMENTS + 1];	// CRC8 lookup table
+
+// Helper function to calculate CRC
+static uint8_t calculate_crc(const char *data, uint8_t size);
+
+// Set up CRC lookup table
+void init_CRC()
+{
+	// Iterate to set a value in every lookup table index
+	for(uint8_t i = 0; i <= CRC8_ELEMENTS; i++)
+	{
+		uint8_t byte = (uint8_t)i;	// Byte to add to lookup table
+
+		// Iterate over every bit in a byte to calculate value to insert
+		for(uint8_t j = 0; j < NUM_BITS_PER_BYTE; j++)
+		{
+			byte <<= 1;
+
+			if(byte & CRC8_MASK)
+			{
+				byte ^= polynomial;
+			}
+		}
+
+		// Insert byte to lookup table
+		crc_table[i] = byte;
+	}
+}
+
+// Calculate CRC to send
+uint8_t encode_CRC(const char *data, uint8_t size)
+{
+	return calculate_crc(data, size);
+}
+
+// Use CRC to detect if there were errors in received data
+bool decode_CRC(const char *data, uint8_t size)
+{
+	return !calculate_crc(data, size);
+}
+
+// Helper function to calculate CRC
+uint8_t calculate_crc(const char *data, uint8_t size)
+{
+	uint8_t crc = 0;
+
+	// Calculate CRC
+	for(uint8_t i = 0; i < size; i++)
+	{
+		uint8_t value = (uint8_t)(data[i] ^ crc);
+		crc = crc_table[value];
+	}
+
+	return crc;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include "Transmitter.h"
 #include "uart_driver.h"
 #include "receiver.h"
+#include "crc.h"
 
 #define F_CPU 16000000UL
 #define baud 19200

--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,7 @@
  * 		none
  */
 int main(void){
+	init_CRC();
 	init_state();
 	init_usart2(baud, F_CPU);
 	init_receiver();


### PR DESCRIPTION
I tested this with various data and data sizes. I did this by generating a random message length of 1-255 and then filling each byte of the message with a random byte. I then called encode_CRC() each time and replaced the CRC8 FCS byte (least significant byte) with the calculated CRC, and then called decode_CRC(), and printed out whether there were errors or not. After 100 cycles of this, no errors occurred: all tests passed.

I then repeated the above process but instead of replacing the CRC8 FCS byte with the calculated CRC, I replaced it with the calculated CRC plus 1 and printed whether there were errors or not. After 100 cycles of this, errors occurred in each instance: all tests passed.

Finally, I repeated the first process but I changed the source address byte to 0x66 and printed whether errors occurred or not. After 100 cycles of this, errors occurred in each instance: all tests passed.

I committed the main.c file I created to perform these tests in a separate branch:
https://github.com/piparocj/networking/tree/crc-test