### PR TITLE
Fix CRC to only CRC message field

### DIFF
--- a/inc/crc.h
+++ b/inc/crc.h
@@ -36,9 +36,10 @@ extern uint8_t encode_CRC(const char *data, uint8_t size);
  *
  * @param data - The data that was received
  * @param size - The number of bytes in 'data'
+ * @param fcs - The FCS to compare the CRC against
  *
  * @return - True if no errors, false if errors
  */
-extern bool decode_CRC(const char *data, uint8_t size);
+extern bool decode_CRC(const char *data, uint8_t size, uint8_t fcs);
 
 #endif	// End compiler guard

--- a/src/crc.c
+++ b/src/crc.c
@@ -48,10 +48,10 @@ uint8_t encode_CRC(const char *data, uint8_t size)
 }
 
 // Use CRC to detect if there were errors in received data
-bool decode_CRC(const char *data, uint8_t size)
+bool decode_CRC(const char *data, uint8_t size, uint8_t fcs)
 {
 	// Calculated CRC will return 0 (false) if no errors
-	return !crc_table[calculate_CRC(data, size) ^ data[0]];
+	return !(calculate_CRC(data, size) ^ fcs);
 }
 
 // Helper function to calculate CRC
@@ -62,7 +62,7 @@ uint8_t calculate_CRC(const char *data, uint8_t size)
 	  // Calculate cumulative CRC for each byte in data
 	  for(int i = 0; i < size; i++)
 	  {
-	    crc = crc_table[crc ^ data[size - i]];
+	    crc = crc_table[crc ^ data[i]];
 	  }
 
 	  return crc;

--- a/startup/startup_stm32.s
+++ b/startup/startup_stm32.s
@@ -11,7 +11,7 @@
    Modified by Darrin Rothe to enable floating point in the reset handler and
    to add weakly defined IRQ vectors.
 */
-	
+
   .syntax unified
   .cpu cortex-m4
   .thumb


### PR DESCRIPTION
Hopefully, this makes sense. Since, to decode the CRC, the CRC calculation needs to be done again. If the newly calculated value is the same as the FCS byte received, XOR-ing them results in 0.

I tested this by just coming up with a few messages and printing out their CRC values. I checked with a few online tools that let you enter strings to do the CRC and compared those with the answers in the tests.

See the test code I wrote here:
https://github.com/piparocj/networking/tree/crc-test