### PR TITLE
Small Final Details

### DIFF
--- a/inc/Collision_Delay.h
+++ b/inc/Collision_Delay.h
@@ -13,6 +13,8 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#include "Manchester_State.h"
+
 //SysTic constants
 #define APB2ENR (volatile uint32_t*) 0x40023844
 #define TIM9_PSK (volatile uint32_t*) 0x40014028

--- a/inc/ringbuffer.h
+++ b/inc/ringbuffer.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 
-#define BUF_SIZE 50
+#define BUF_SIZE 255
 #define BACK_SPACE 127
 
 typedef struct {

--- a/src/Collision_Delay.c
+++ b/src/Collision_Delay.c
@@ -61,6 +61,8 @@ void setDelayTimeout(){
 		//compare to radnom milliseconds
 		*(TIM9_CCR1) = (n);
 
+		while(getState() == COLLISION){}
+
 		//enable the counter by setting CEN bit in CR1
 		*(TIM9_CR1) |= 1;
 

--- a/src/Transmitter.c
+++ b/src/Transmitter.c
@@ -104,10 +104,10 @@ void package_frame(uint8_t dest, char* message, uint8_t length, uint8_t crc){
 	packedFrame[3] = dest;
 	packedFrame[4] = length;
 	packedFrame[5] = CRC_FLAG;
-	strncpy(&packedFrame[6], message, length);
+	memcpy(&packedFrame[6], message, length);
 	packedFrame[6 + length] = crc;
 
-	strncpy(frameToSend.message, packedFrame, length + 7);
+	memcpy(frameToSend.message, packedFrame, length + 7);
 }
 
 void TIM5_IRQHandler(){

--- a/src/main.c
+++ b/src/main.c
@@ -100,7 +100,17 @@ static UserInput* getInput(){
 		char* command = strtok(input.buffer, " ");
 		char* address = strtok('\0', " ");
 		char* message = strtok('\0', " ");
+
 		char* next_token = strtok('\0', " ");
+		char finalMessage[255];
+
+		strcpy(finalMessage, message);
+
+		while(next_token != '\0'){
+			strncat(finalMessage, " ", 1);
+			strcat(finalMessage, next_token);
+			next_token = strtok('\0', " ");
+		}
 
 		if(!(command && address && message) || next_token){
 			printUsage();
@@ -109,7 +119,7 @@ static UserInput* getInput(){
 		}
 
 		strncpy(input.command, command, 5);
-		strncpy(input.message, message, 256);
+		strncpy(input.message, finalMessage, 256);
 
 		char** end;
 		input.dest = strtol(address, end, 10);

--- a/src/receiver.c
+++ b/src/receiver.c
@@ -157,13 +157,19 @@ void receive(){
 		uint8_t messageLength = temp[LENGTH_OFFSET];
 		uint8_t dest = temp[DEST_OFFSET];
 		uint8_t fcs = temp[MESSAGE_OFFSET + messageLength];
+		uint8_t src = temp[SOURCE_OFFSET];
+		uint8_t crc = temp[CRC_OFFSET];
 
 		char message[messageLength + 1];
 		strncpy(message, &temp[MESSAGE_OFFSET], messageLength);
 
-		bool validMessage = decode_CRC(message, messageLength, fcs);
+		bool validMessage = true;
 
-		if(validMessage && (dest == 21 || dest == 0)){
+		if(crc != 0x00){
+			validMessage = decode_CRC(message, messageLength, fcs);
+		}
+
+		if(validMessage && (dest == 21 || dest == 0) && src != 21){
 
 			//send characters to console out
 			for(int i = 0; i < messageLength; i++){
@@ -175,7 +181,7 @@ void receive(){
 			}
 			usart2_putch('\r');
 			usart2_putch('\n');
-		}else if(!validMessage){
+		}else if(!validMessage  && (dest == 21 || dest == 0) && src != 21){
 			for(int i = 0; DATA_CORRUPT[i] != '\0'; i++){
 				usart2_putch(DATA_CORRUPT[i]);
 			}


### PR DESCRIPTION
This pull request contains the following fixes:
* Increased the ring buffer size from 50 bytes to 255 bytes.
* Introduced a busy wait in the `setDelayTimeout` to prevent the timer from starting prior to the state of the bus changing out of the collision state.

This list will be updated as additional changes are made.